### PR TITLE
Add roles and skills mapping

### DIFF
--- a/docs/roles-and-skills.md
+++ b/docs/roles-and-skills.md
@@ -1,0 +1,67 @@
+# Roles and Skills Analysis
+
+## Components and roles
+
+- **Mobile App (Client)**
+  - Mobile Engineer (iOS)
+  - Mobile Engineer (Android)
+  - QA Automation Engineer (Mobile)
+  - UI/UX Designer (Technical impl.)
+
+- **API Gateway**
+  - Backend Engineer (Go/C++)
+  - Security Engineer
+  - DevOps Engineer
+
+- **Auth Service**
+  - Backend Engineer (Identity/Security focus)
+  - Database Administrator (DBA)
+  - Security Engineer
+
+- **Order Service**
+  - Backend Engineer (Generalist)
+  - QA Engineer (API/Integration)
+  - Database Administrator
+
+- **Dispatch / Matching Engine**
+  - Data Scientist / ML Engineer
+  - Backend Engineer (High performance/Algorithms)
+  - Data Engineer
+
+- **Infrastructure & Deployment (General)**
+  - Site Reliability Engineer (SRE)
+  - DevOps Engineer
+  - Cloud Platform Engineer
+
+## Roles and responsibilities
+
+1. **Mobile Engineer (iOS/Android)**
+    - Develops and maintains the user-facing application, ensuring high performance and smooth animations.
+    - Implements UI screens based on designs and integrates with backend APIs to fetch data (rides, prices).
+
+2. **Backend Engineer**
+    - Designs and implements server-side logic, microservices, and APIs.
+    - Optimizes database queries and ensures the services can handle high concurrency (thousands of requests per second).
+
+3. **DevOps / Site Reliability Engineer (SRE)**
+    - Manages the cloud infrastructure (Kubernetes, Docker) and CI/CD pipelines.
+    - Monitors system health, sets up alerts, and ensures high availability and scalability of the platform.
+
+4. **QA Automation Engineer**
+    - Writes automated tests (unit, integration, end-to-end) to prevent regressions.
+    - Maintains the testing infrastructure and ensures the quality of releases before they reach production.
+
+5. **Data Scientist / ML Engineer**
+    - Develops and trains machine learning models for dynamic pricing, dispatch matching, and route optimization.
+    - Analyzes historical data to improve the efficiency of the marketplace algorithms.
+
+## Common skills across roles
+
+Based on the roles above, the following technical skills and practices are essential across the team:
+
+- **Version Control:** Proficiency with Git (branching, merging, pull requests).
+- **API Knowledge:** Understanding of RESTful APIs, HTTP methods, and JSON data formats.
+- **Agile Methodologies:** Experience working in Scrum/Kanban, using task trackers (Jira/YouTrack).
+- **Containerization:** Basic understanding of Docker and how applications are containerized.
+- **Problem Solving:** Ability to debug complex issues and read system logs.
+- **Collaboration:** Code review practices and writing technical documentation.


### PR DESCRIPTION
## Summary

This PR creates `docs/roles-and-skills.md` to map Yandex Go architectural components to the necessary IT roles. It includes detailed responsibilities for five key roles (Mobile Engineer, Backend Engineer, QA, etc.) and a list of common technical skills required across the team.

- Closes #5 
---

## Checklist

- [x] I made this PR to the `main` branch **of my fork (NOT the original repo)**.
- [x] I linked at least one issue (`Closes #<issue-number>`).
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the code I’m submitting (not blindly copy-pasted).